### PR TITLE
chore: align @types/node with node version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,10 @@ updates:
         update-types:
           - "patch"
           - "minor"
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"
     versioning-strategy: "increase-if-necessary"
     open-pull-requests-limit: 20
     reviewers:

--- a/.ncurc.major.cjs
+++ b/.ncurc.major.cjs
@@ -2,6 +2,13 @@ const minorConfig = require('./.ncurc.minor.cjs');
 
 module.exports = {
   ...minorConfig,
-  reject: [...minorConfig.reject, 'eslint', 'eslint-plugin-json', 'style-dictionary'],
+  reject: [
+    ...minorConfig.reject,
+    // @types/node is kept in line with the node version in .nvmrc and package.json#engines.node
+    '@types/node',
+    'eslint',
+    'eslint-plugin-json',
+    'style-dictionary',
+  ],
   target: 'latest',
 };

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "url": "git@github.com:nl-design-system/basis.git",
     "directory": "."
   },
+  "packageManager": "pnpm@9.12.2+sha512.22721b3a11f81661ae1ec68ce1a7b879425a1ca5b991c975b074ac220b187ce56c708fe5db69f4c962c989452eee76c82877f4ee80f474cebd61ee13461b6228",
   "engines": {
     "node": "^20",
     "pnpm": "^9"
@@ -71,6 +72,5 @@
   },
   "dependencies": {
     "http-server": "14.1.1"
-  },
-  "packageManager": "pnpm@9.7.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "packageManager": "pnpm@9.12.2+sha512.22721b3a11f81661ae1ec68ce1a7b879425a1ca5b991c975b074ac220b187ce56c708fe5db69f4c962c989452eee76c82877f4ee80f474cebd61ee13461b6228",
   "engines": {
+    "//": "Update @types/node when updating this node version",
     "node": "^20",
     "pnpm": "^9"
   },
@@ -23,7 +24,7 @@
   ],
   "devDependencies": {
     "@changesets/cli": "2.27.8",
-    "@types/node": "22.5.5",
+    "@types/node": "20.14.13",
     "@typescript-eslint/eslint-plugin": "8.6.0",
     "@typescript-eslint/parser": "8.6.0",
     "eslint": "8.57.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         specifier: 2.27.8
         version: 2.27.8
       '@types/node':
-        specifier: 22.5.5
-        version: 22.5.5
+        specifier: 20.14.13
+        version: 20.14.13
       '@typescript-eslint/eslint-plugin':
         specifier: 8.6.0
         version: 8.6.0(@typescript-eslint/parser@8.6.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2)


### PR DESCRIPTION
Align @types/node with the version of node that is used in the repo. Add a comment to update @types/node when the node version in the repo is bumped.

Prevent Dependabot from bumping @types/node major versions.