### PR TITLE
fix: changeset typo

### DIFF
--- a/.changeset/milky-food-lion.md
+++ b/.changeset/milky-food-lion.md
@@ -1,5 +1,5 @@
 ---
-'@nl-design-system/rollup-config-react-components': patch
+'@nl-design-system/rollup-config-react-component': patch
 ---
 
 Make sure the individual example installation commands can be copied using GitHub's UI


### PR DESCRIPTION
When an unknown package is referenced in a changeset file, this error shows up in the pipeline logs

> TypeError: Cannot destructure property 'packageJson' of 'undefined' as
it is undefined.

In this instance there was a typo `components` instead of `component` which is a good indication that using

```shell
pnpm changeset
```

is probable the best way to generate these files