### PR TITLE
fix: loosen rollup peerDependency

### DIFF
--- a/.changeset/famous-singers-prove.md
+++ b/.changeset/famous-singers-prove.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system/rollup-config-react-component': patch
+---
+
+Relax rollup peerDependency requirement

--- a/packages/rollup-config-react-component/package.json
+++ b/packages/rollup-config-react-component/package.json
@@ -33,6 +33,6 @@
     "rollup": "4.24.3"
   },
   "peerDependencies": {
-    "rollup": "4.24.3"
+    "rollup": "^4"
   }
 }


### PR DESCRIPTION
The peerDependency for rollup should have been ^4 instead of a pinned version.