### PR TITLE
chore: add missing peer dependency

### DIFF
--- a/.changeset/late-jokes-wash.md
+++ b/.changeset/late-jokes-wash.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system/tsconfig': patch
+---
+
+Add missing peer dependency typescript@^5.4

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -17,5 +17,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "typescript": "5.6.3"
+  },
+  "peerDependencies": {
+    "typescript": "^5.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,7 +126,11 @@ importers:
         specifier: 4.24.4
         version: 4.24.4
 
-  packages/tsconfig: {}
+  packages/tsconfig:
+    devDependencies:
+      typescript:
+        specifier: 5.6.3
+        version: 5.6.3
 
 packages:
 


### PR DESCRIPTION
Add typescript@^5.4 as a peer dependency for the tsconfig package because of `"module": "preserve"`

Closes #34 