### PR TITLE
feat: factor out nlDesignSystemConfig

### DIFF
--- a/.changeset/loud-squids-nail.md
+++ b/.changeset/loud-squids-nail.md
@@ -1,0 +1,6 @@
+---
+'@nl-design-system/eslint-config': minor
+---
+
+Make the NL Design System specific rules that are not part of ESLint's recommended rules available as a separate export
+as part of a refactor where the whole of `@nl-design-system/eslint-config` becomes more modular and reusable.

--- a/packages/eslint-config/configs/nl-design-system.config.mjs
+++ b/packages/eslint-config/configs/nl-design-system.config.mjs
@@ -1,0 +1,45 @@
+import { defineConfig } from 'eslint/config';
+
+export default defineConfig([
+  {
+    rules: {
+      'array-callback-return': [
+        'error',
+        {
+          checkForEach: false,
+        },
+      ],
+      'block-scoped-var': 'error',
+      'consistent-return': 'error',
+      eqeqeq: 'error',
+      'no-alert': 'error',
+      'no-caller': 'error',
+      'no-constructor-return': 'error',
+      'no-eval': 'error',
+      'no-implicit-globals': 'error',
+      'no-implied-eval': 'error',
+      'no-inner-declarations': 'error',
+      'no-invalid-this': 'error',
+      'no-lone-blocks': 'error',
+      'no-loop-func': 'error',
+      'no-multi-str': 'error',
+      'no-new-func': 'error',
+      'no-new-wrappers': 'error',
+      'no-octal-escape': 'error',
+      'no-param-reassign': 'error',
+      'no-return-assign': 'error',
+      'no-self-compare': 'error',
+      'no-sequences': 'error',
+      'no-throw-literal': 'error',
+      'no-unmodified-loop-condition': 'error',
+      'no-unused-expressions': 'error',
+      'no-useless-call': 'error',
+      'no-useless-concat': 'error',
+      'no-useless-return': 'error',
+      'no-void': 'error',
+      'prefer-regex-literals': 'error',
+      radix: 'error',
+      yoda: 'error',
+    },
+  },
+]);

--- a/packages/eslint-config/eslint.config.mjs
+++ b/packages/eslint-config/eslint.config.mjs
@@ -1,6 +1,7 @@
 import js from '@eslint/js';
 import json from '@eslint/json';
 import eslintConfigPrettier from 'eslint-config-prettier';
+import nlDesignSystemConfig from './configs/nl-design-system.config.mjs';
 import perfectionist from 'eslint-plugin-perfectionist';
 import react from 'eslint-plugin-react';
 import { globalIgnores } from 'eslint/config';
@@ -68,58 +69,8 @@ export default tseslint.config(
   },
   {
     name: 'nl-design-system/all',
-    files: ['**/*.js', '**/*.cjs', '**/*.cjs', '**/*.ts', '**/*.jsx', '**/*.tsx'],
-    rules: {
-      'array-callback-return': ['error', { checkForEach: false }],
-      'block-scoped-var': 'error',
-      'consistent-return': 'error',
-      eqeqeq: 'error',
-      'no-alert': 'error',
-      'no-caller': 'error',
-      'no-constructor-return': 'error',
-      'no-eval': 'error',
-      'no-implicit-globals': 'error',
-      'no-implied-eval': 'error',
-      'no-inner-declarations': 'error',
-      'no-invalid-this': 'error',
-      'no-lone-blocks': 'error',
-      'no-loop-func': 'error',
-      'no-multi-str': 'error',
-      'no-new-func': 'error',
-      'no-new-wrappers': 'error',
-      'no-octal-escape': 'error',
-      'no-param-reassign': 'error',
-      'no-return-assign': 'error',
-      'no-self-compare': 'error',
-      'no-sequences': 'error',
-      'no-throw-literal': 'error',
-      'no-unmodified-loop-condition': 'error',
-      'no-unused-expressions': 'error',
-      'no-useless-call': 'error',
-      'no-useless-concat': 'error',
-      'no-useless-return': 'error',
-      'no-void': 'error',
-      'perfectionist/sort-imports': [
-        'error',
-        {
-          ignoreCase: false,
-          newlinesBetween: 'never',
-        },
-      ],
-      'perfectionist/sort-objects': [
-        'error',
-        {
-          customGroups: {
-            first: ['id', 'name'],
-            last: ['overrides'],
-          },
-          groups: ['first', 'unknown', 'last'],
-        },
-      ],
-      'prefer-regex-literals': 'error',
-      radix: 'error',
-      yoda: 'error',
-    },
+    files: ['**/*.{js,cjs,mjs,jsx,ts,tsx}'],
+    extends: [nlDesignSystemConfig],
   },
   {
     name: 'eslint-config-prettier',

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -7,10 +7,12 @@
   "type": "module",
   "main": "./eslint.config.mjs",
   "exports": {
-    ".": "./eslint.config.mjs"
+    ".": "./eslint.config.mjs",
+    "./configs/*.mjs": "./configs/*.mjs"
   },
   "files": [
-    "./eslint.config.mjs"
+    "./eslint.config.mjs",
+    "./configs/*.mjs"
   ],
   "repository": {
     "type": "git+ssh",


### PR DESCRIPTION
Move the specific NL Design System rules that are not part of ESLint's own recommended config into its own file and make this file available.