### PR TITLE
ci: enable npm publishing with OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: publish
 
     steps:
       - name: Checkout
@@ -33,6 +34,11 @@ jobs:
 
       - name: Build
         run: pnpm run build
+
+      - name: Set up Node.js that is compatible with OIDC
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 24
 
       - name: Publish to the npm Registry
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+# We do not use npm, but if it was ever run by accident, this should make sure that pre- and post-install scripts will
+# NOT run. This is more or less in line with pnpm behaviour where pre- and post-install scripts need to be added using
+# pnpm approve-builds
+ignore-scripts=true
+
+provenance=true

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "packageManager": "pnpm@10.12.4+sha512.5ea8b0deed94ed68691c9bad4c955492705c5eeb8a87ef86bc62c74a26b037b08ff9570f108b2e4dbd1dd1a9186fea925e527f141c648e85af45631074680184",
   "engines": {
     "//": "Update @types/node to match the highest node version here",
-    "node": ">=20 <=22",
+    "node": ">=20 <=24",
     "pnpm": "^10"
   },
   "devDependencies": {


### PR DESCRIPTION
All these packages have been configured to require OIDC:

<img width="553" height="360" alt="Screenshot 2025-10-26 at 20 53 44" src="https://github.com/user-attachments/assets/ff8fb8a0-dd4b-4868-a3a1-a0c9ed6a6cd3" />
