### PR TITLE
chore(eslint-config): ignore variables with an underscore

### DIFF
--- a/.changeset/tough-moments-see.md
+++ b/.changeset/tough-moments-see.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system/eslint-config': minor
+---
+
+De rule `@typescript-eslint/no-unused-vars`, met een ignore patterns `^_`, toegevoegd

--- a/packages/eslint-config/eslint.config.mjs
+++ b/packages/eslint-config/eslint.config.mjs
@@ -28,6 +28,17 @@ export default tseslint.config(
     name: 'typescript-eslint/configs/strict',
     extends: [...tseslint.configs.strict],
     files: ['**/*.ts', '**/*.mts', '**/*.tsx'],
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+          ignoreRestSiblings: true,
+        },
+      ],
+    },
   },
   {
     name: 'eslint-plugin-perfectionist/recommended-natural',


### PR DESCRIPTION
In de documentatie repo staat de rule `'@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }]`

Deze miste in de gedeelde eslint config. Dit zorgt er voor dat er geen variabelen ongebruikt mogen zijn, behalve als ze zijn geprefixed met een underscore.

Typescript heeft deze behaviour out of the box, deze change brengt de eslint config in lijn met typescript
