### PR TITLE
chore: add eslint v10 to eslint-config peerDependencies

### DIFF
--- a/.changeset/fifty-cats-speak.md
+++ b/.changeset/fifty-cats-speak.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system/eslint-config': patch
+---
+
+chore: add eslint v10 to eslint-config peerDependencies'

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -27,7 +27,7 @@
     "eslint": "9.39.2"
   },
   "peerDependencies": {
-    "eslint": "^9.22.0"
+    "eslint": "^9.22.0 || ^10.0.0"
   },
   "dependencies": {
     "@eslint/js": "9.39.2",


### PR DESCRIPTION
We draaien sinds kort eslint v10 in de theme-wizard en `pnpm install` geeft een hoop peerDependency warnings. De lint config werkt nochtans wel, dus een opt-in voor v10 is misschien op zijn plaats?