### PR TITLE
ci: setup CODEOWNERS file (and fix dependabot.yml)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,6 @@
-# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# See: https://nldesignsystem.nl/codeowners
 
-# Changes to any file require approval from @nl-design-system/kernteam-committer
 * @nl-design-system/kernteam-committer
 
-# Changes to this file (.github/CODEOWNERS) require approval from @nl-design-system/kernteam-admin
+# Protect this file itself (order matters, keep this line last):
 .github/CODEOWNERS @nl-design-system/kernteam-admin

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
     groups:
       github-actions:
         applies-to: "version-updates"
+        patterns:
+          - "*"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:


### PR DESCRIPTION
This PR updates the CODEOWNERS file to ensure that the correct people are assigned as reviewers for PRs.

- If the file did not exist yet, it was created.
- The pattern `*` was added with suggested approvers - please check and adjust as needed.
- Comments were aligned across all repos - just one reference to the relevant NL Design System documentation page at the top and a note about the order of the patterns.
- Additionally, the CODEOWNERS file itself was updated to protect the file itself.
  For community repos, the relevant `-admin` team is added as a reviewer.
  `kernteam-admin` is also added.
  Good to know: if multiple patterns match, the last pattern takes precedence, and that's why the CODEOWNERS file itself is at the bottom.

## FAQ

### I don't want to be assigned as a reviewer

When this PR is merged, PRs that match the pattern in the CODEOWNERS file will be automatically assigned to the approvers.  If this creates too much noise, you can
1. check your [notification settings](https://github.com/settings/notifications),
2. remove yourself from the CODEOWNERS file (if you are added through a team, you can change the team, or change the pattern to assign individual reviewers)

### How do I enforce that a PR has at least one review from the approvers?

Optionally, a branch protection rule can be created to _require_ reviews.  This is not done in this PR (needs a Terraform change) so let us know if you want this to be added.
