### PR TITLE
chore: configure dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,13 +19,91 @@ updates:
     cooldown:
       default-days: 1
     groups:
-      patch-and-minor-dependencies:
+      nl-design-system:
+        applies-to: "version-updates"
+        patterns:
+          - "@amsterdam/*"
+          - "@gemeente-denhaag/*"
+          - "@gemeente-rotterdam/*"
+          - "@nl-design-system/*"
+          - "@nl-design-system-candidate/*"
+          - "@nl-design-system-community/*"
+          - "@nl-design-system-unstable/*"
+          - "@nl-rvo/*"
+          - "@rijkshuisstijl-community/*"
+      react:
+        applies-to: "version-updates"
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      astro:
+        applies-to: "version-updates"
+        patterns:
+          - "astro"
+          - "@astrojs/*"
+      storybook:
+        applies-to: "version-updates"
+        patterns:
+          - "@storybook/*"
+          - "storybook"
+      docusaurus:
+        applies-to: "version-updates"
+        patterns:
+          - "@docusaurus/*"
+      i18next:
+        applies-to: "version-updates"
+        patterns:
+          - "i18next"
+          - "i18next-*"
+          - "react-i18next"
+      build-toolchain:
+        applies-to: "version-updates"
+        patterns:
+          - "@babel/*"
+          - "@rollup/*"
+          - "@vitejs/*"
+          - "rollup"
+          - "vite"
+      test-toolchain:
+        applies-to: "version-updates"
+        patterns:
+          - "@testing-library/*"
+          - "@vitest/*"
+          - "jsdom"
+          - "vitest"
+      lint-toolchain:
+        applies-to: "version-updates"
+        patterns:
+          - "@eslint/*"
+          - "eslint"
+          - "husky"
+          - "lint-staged"
+          - "markdownlint-cli"
+          - "npm-package-json-lint"
+          - "prettier"
+          - "stylelint"
+          - "stylelint-*"
+      patch-and-minor-updates:
         applies-to: "version-updates"
         update-types:
           - "patch"
           - "minor"
     ignore:
       - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "@types/react"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "@types/react-dom"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "react"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "react-dom"
         update-types:
           - "version-update:semver-major"
     versioning-strategy: "increase-if-necessary"


### PR DESCRIPTION
Configure dependabot groups so packages upgrades are grouped logically together. This helps to reduce the number of invididual PRs for major upgrades and makes the minor/patch update group smaller. Thus making it easier to review, test and merge.

The groups were taken from the example repository.

Tested with: `pnpm dlx @bugron/validate-dependabot-yaml@0.3.3 .github/dependabot.yml`
